### PR TITLE
Optimize smoke tests: expand from 2 to 9 targeted checks

### DIFF
--- a/.github/workflows/runworkflow.yml
+++ b/.github/workflows/runworkflow.yml
@@ -47,33 +47,79 @@ jobs:
     name: Smoke Tests
     runs-on: ubuntu-latest
     needs: job-sync-website
+    env:
+      SITE_URL: "https://www.marcbacchi.dev"
+      ROOT_URL: "https://marcbacchi.dev"
+      API_URL: "https://d503n28gj5.execute-api.us-east-1.amazonaws.com/"
     steps:
-      - name: Website accessibility check
+      - name: "1 — HTTPS site returns 200"
         run: |
-          WEBSITE_URL="https://www.marcbacchi.dev"
-          status=$(curl -s -o /dev/null -w "%{http_code}" "$WEBSITE_URL")
-          echo "Website Status: $status"
-          if [ "$status" != "200" ]; then
-            echo "Website returned status $status (expected 200)"
-            exit 1
-          fi
-          echo "Website is accessible (HTTP 200)"
+          status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$SITE_URL")
+          echo "Status: $status"
+          [ "$status" = "200" ] || { echo "Expected 200, got $status"; exit 1; }
+          echo "PASS"
 
-      - name: Website content verification
+      - name: "2 — HTTP redirects to HTTPS"
         run: |
-          WEBSITE_URL="https://www.marcbacchi.dev"
-          response=$(curl -s "$WEBSITE_URL")
+          status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "http://www.marcbacchi.dev")
+          echo "HTTP→HTTPS redirect status: $status"
+          [[ "$status" == "301" || "$status" == "302" ]] || { echo "Expected 301/302, got $status"; exit 1; }
+          echo "PASS"
 
-          if ! echo "$response" | grep -q "<!DOCTYPE"; then
-            echo "Website missing DOCTYPE declaration"
-            exit 1
-          fi
-          if ! echo "$response" | grep -qi "marc bacchi"; then
-            echo "Website missing name content"
-            exit 1
-          fi
-          if ! echo "$response" | grep -qi "cloud\|aws\|infrastructure"; then
-            echo "Website missing professional content"
-            exit 1
-          fi
-          echo "Website content verification passed"
+      - name: "3 — Non-www redirects to www"
+        run: |
+          location=$(curl -sI --max-time 10 "$ROOT_URL" | grep -i "^location:" | tr -d '\r\n')
+          echo "Redirect: $location"
+          echo "$location" | grep -qi "www\.marcbacchi\.dev" || { echo "Expected redirect to www; got: $location"; exit 1; }
+          echo "PASS"
+
+      - name: "4 — HTML content sanity"
+        run: |
+          body=$(curl -s --max-time 10 "$SITE_URL")
+          failed=0
+          echo "$body" | grep -q "<!DOCTYPE"                        || { echo "FAIL: Missing DOCTYPE"; failed=1; }
+          echo "$body" | grep -q 'lang='                            || { echo "FAIL: Missing lang attribute"; failed=1; }
+          echo "$body" | grep -qi "marc bacchi"                     || { echo "FAIL: Missing name"; failed=1; }
+          echo "$body" | grep -qi "cloud\|aws\|infrastructure"      || { echo "FAIL: Missing professional keywords"; failed=1; }
+          [ "$failed" -eq 0 ] && echo "PASS" || exit 1
+
+      - name: "5 — CSS asset loads with correct Content-Type"
+        run: |
+          css_url="${SITE_URL}/styles.css"
+          status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$css_url")
+          echo "styles.css status: $status"
+          [ "$status" = "200" ] || { echo "styles.css returned $status"; exit 1; }
+          ct=$(curl -sI --max-time 10 "$css_url" | grep -i "^content-type:" | tr -d '\r\n')
+          echo "Content-Type: $ct"
+          echo "$ct" | grep -qi "text/css" || { echo "Wrong Content-Type for CSS: $ct"; exit 1; }
+          echo "PASS"
+
+      - name: "6 — Response served via CloudFront"
+        run: |
+          via=$(curl -sI --max-time 10 "$SITE_URL" | grep -i "^via:" | tr -d '\r\n')
+          echo "Via: $via"
+          echo "$via" | grep -qi "cloudfront" || { echo "Response not from CloudFront; Via: $via"; exit 1; }
+          echo "PASS"
+
+      - name: "7 — API endpoint returns JSON with count"
+        run: |
+          status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$API_URL")
+          echo "API status: $status"
+          [ "$status" = "200" ] || { echo "API returned $status"; exit 1; }
+          body=$(curl -s --max-time 10 "$API_URL")
+          echo "API response: $body"
+          echo "$body" | grep -q '"count"' || { echo "API response missing 'count' field; got: $body"; exit 1; }
+          echo "PASS"
+
+      - name: "8 — API CORS header present"
+        run: |
+          cors=$(curl -sI --max-time 10 "$API_URL" | grep -i "^access-control-allow-origin:" | tr -d '\r\n')
+          echo "CORS: $cors"
+          [ -n "$cors" ] || { echo "Missing Access-Control-Allow-Origin header"; exit 1; }
+          echo "PASS"
+
+      - name: "9 — Time to first byte under 3s"
+        run: |
+          ttfb=$(curl -s -o /dev/null -w "%{time_starttransfer}" --max-time 10 "$SITE_URL")
+          echo "TTFB: ${ttfb}s"
+          awk -v t="$ttfb" 'BEGIN { if (t+0 > 3.0) { print "TTFB too slow: " t "s (limit: 3s)"; exit 1 } print "PASS: " t "s" }'


### PR DESCRIPTION
  ## Summary

  - Replaces 2 basic curl checks with 9 discrete smoke tests, each numbered and independently failing
  - Centralizes target URLs into `env` block for easy maintenance
  - Adds `--max-time 10` to every curl call to prevent silent hangs

  ## New tests

  | # | Test | What it catches |
  |---|------|-----------------|
  | 1 | HTTPS site returns 200 | Baseline — site is up *(existing, improved)* |
  | 2 | HTTP → HTTPS redirect | CloudFront `redirect-to-https` policy broken |
  | 3 | Non-www → www redirect | Root bucket redirect or CloudFront routing broken |
  | 4 | HTML content sanity | DOCTYPE, `lang=`, name, keywords *(extended from original)* |
  | 5 | CSS asset + Content-Type | styles.css missing or served with wrong MIME type |
  | 6 | Served via CloudFront | Response bypassing CDN (direct S3 hit, routing change) |
  | 7 | API returns JSON `{count}` | Lambda/DynamoDB visitor counter broken end-to-end |
  | 8 | API CORS header present | `Access-Control-Allow-Origin` missing — counter silently fails in browser |
  | 9 | TTFB < 3s | CloudFront cache miss or origin latency regression |

  ## Follow-up suggestions (require infra changes, not in this PR)

  - **HSTS + security headers**: Add a CloudFront Response Headers Policy with `Strict-Transport-Security`, `X-Frame-Options`, and `X-Content-Type-Options` — S3 website origin doesn't send these natively
  - **Restrict API CORS to site origin**: Change `allow_origins = ["*"]` → `["https://www.marcbacchi.dev"]` — stops arbitrary callers from incrementing the visitor count
  - **S3 + CloudFront OAC**: Serve S3 via Origin Access Control instead of `public-read` ACL — bucket stays fully private, CloudFront is the only allowed reader