### PR TITLE
Fix CORS smoke test: send Origin header to trigger API Gateway CORS r…

### DIFF
--- a/.github/workflows/runworkflow.yml
+++ b/.github/workflows/runworkflow.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: "8 — API CORS header present"
         run: |
-          cors=$(curl -sI --max-time 10 "$API_URL" | grep -i "^access-control-allow-origin:" | tr -d '\r\n')
+          cors=$(curl -sI --max-time 10 -H "Origin: $SITE_URL" "$API_URL" | grep -i "^access-control-allow-origin:" | tr -d '\r\n')
           echo "CORS: $cors"
           [ -n "$cors" ] || { echo "Missing Access-Control-Allow-Origin header"; exit 1; }
           echo "PASS"


### PR DESCRIPTION
…esponse

API Gateway only returns Access-Control-Allow-Origin when the request includes an Origin header, matching browser behavior.