### PR TITLE
Add second Credly badge and update project description

### DIFF
--- a/resume-site/index.html
+++ b/resume-site/index.html
@@ -37,7 +37,7 @@
           </div>
             <div class="project_title">
                 <h3 class="project_title_item">Cloud Resume Challenge <span class='project_date'>| Feb 2022</span></h3>
-                <p class="project_description">Built this website using AWS, S3, IAM, Lambda, DynamoDB, API Gateway, CloudFront, Route 53, and ACM Certificates.</p>
+                <p class="project_description">Built this page using more than 10 AWS services for just a static website. See Github for service diagram.</p>
                 <p class="project_description">Infrastructure is managed with Terraform (IaC), and deployments are automated via GitHub Actions CI/CD, triggered on pull request merges to <code>main branch</code>. Cypress handles testing for HTML/CSS integrity and URL liveness.</p>
                 <p class="project_description">
                     Browse the code in my <a href="https://github.com/marcbacchi/cloud-resume-challenge" target="_blank">GitHub Repo</a>,
@@ -133,7 +133,8 @@
           </ul>
         </div>
         <div class="credential_badge">
-          <div data-iframe-width="220" data-iframe-height="220" data-share-badge-id="4bd3290d-6ac5-4a38-82a5-2e43df07d2cc" data-share-badge-host="https://www.credly.com"></div>
+          <div data-iframe-width="150" data-iframe-height="150" data-share-badge-id="772e9602-df92-4ab7-b570-693f175519e2" data-share-badge-host="https://www.credly.com"></div>
+          <div data-iframe-width="150" data-iframe-height="150" data-share-badge-id="4bd3290d-6ac5-4a38-82a5-2e43df07d2cc" data-share-badge-host="https://www.credly.com"></div>
         </div>
         <script type="text/javascript" async src="//cdn.credly.com/assets/utilities/embed.js"></script>
       </div>

--- a/resume-site/styles.css
+++ b/resume-site/styles.css
@@ -130,7 +130,10 @@ html *{
 }
 .credential_badge{
     display: flex;
+    flex-direction: column;
+    align-items: center;
     justify-content: center;
+    gap: 5px;
     padding: 10px 0;
     overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- Add newly earned Credly badge, stacked above the existing (soon-to-expire) badge
- Resize badges (220px → 150px) and stack vertically so both fit in the same space
- Update the Cloud Resume Challenge project description text

## Test plan
- [ ] Visually confirm both badges render and are vertically stacked, new badge on top
- [ ] Confirm badge sizing looks correct on desktop and mobile widths
- [ ] Confirm updated project description text reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)