### PR TITLE
Swap title order to lead with Cloud Infrastructure

### DIFF
--- a/resume-site/index.html
+++ b/resume-site/index.html
@@ -23,7 +23,7 @@
     <div class="upper_container">
       <div class="name_info">
         <h1 class="name">Marc Bacchi</h1>
-        <h2 class="title">Site Reliability&nbsp;&nbsp;|&nbsp;&nbsp;Cloud Infrastructure</h2>
+        <h2 class="title">Cloud Infrastructure&nbsp;&nbsp;|&nbsp;&nbsp;Site Reliability</h2>
         <h3 class="contact_info">Phoenix, Arizona&nbsp;&nbsp;USA&nbsp;&nbsp;|&nbsp;&nbsp;bacchimarc@pm.me</h3>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Reorder the title heading so "Cloud Infrastructure" leads, followed by "Site Reliability"

## Test plan
- [ ] Visually confirm the title reads "Cloud Infrastructure | Site Reliability"

🤖 Generated with [Claude Code](https://claude.com/claude-code)